### PR TITLE
add -yes flag and modify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ Continue? [yes]:
 2025/08/03 00:11:19 rebooting system
 ```
 
+## Non-interactive installation
+
+You can run `boot-to-talos` in fully automated mode by passing the required flags.  
+To skip all interactive prompts, use the `-yes` flag:
+
+```console
+boot-to-talos -yes
+```
+
+You can also specify all parameters explicitly:
+
+```console
+boot-to-talos -yes -disk /dev/sda -image ghcr.io/cozystack/cozystack/talos:v1.10.5 -image-size-gib 4 -extra-kernel-arg "console=ttyS0"
+```
+
+## Available command-line flags
+
+| Flag                  | Description                                                        | Example                                         |
+|-----------------------|--------------------------------------------------------------------|-------------------------------------------------|
+| `-yes`                | Run non-interactively, do not ask for confirmation                 | `-yes`                                          |
+| `-disk string`        | Target disk (will be wiped)                                        | `-disk /dev/sda`                                |
+| `-image string`       | Talos installer image (default: `ghcr.io/cozystack/cozystack/talos:v1.10.5`) | `-image ghcr.io/cozystack/cozystack/talos:v1.10.5` |
+| `-image-size-gib uint`| Size of image.raw in GiB (default: 2)                              | `-image-size-gib 4`                             |
+| `-extra-kernel-arg value` | Extra kernel argument (can be repeated)                        | `-extra-kernel-arg "console=ttyS0"`             |
+
+**Tip:** All flags can be combined. If a flag is not provided, the installer will prompt for input (unless `-yes` is used).
+
 ---
 
 Created for the Cozystack project. 🚀

--- a/main.go
+++ b/main.go
@@ -34,12 +34,14 @@ func (m *multiFlag) Set(v string) error { *m = append(*m, v); return nil }
 var (
 	imageFlag string
 	diskFlag  string
+	yesFlag   bool
 )
 
 func init() {
 	flag.StringVar(&imageFlag, "image",
 		"ghcr.io/cozystack/cozystack/talos:v1.10.5", "Talos installer image")
 	flag.StringVar(&diskFlag, "disk", "", "target disk (will be wiped)")
+	flag.BoolVar(&yesFlag, "yes", false, "automatic yes to prompts")
 }
 
 /* ------------------------------ helpers ----------------------------------- */
@@ -96,6 +98,10 @@ func fakeCert() string {
 var reader = bufio.NewReader(os.Stdin)
 
 func ask(msg, def string) string {
+	if yesFlag {
+		fmt.Printf("%s [%s]: %s\n", msg, def, def)
+		return def
+	}
 	fmt.Printf("%s [%s]: ", msg, def)
 	t, _ := reader.ReadString('\n')
 	t = strings.TrimSpace(t)
@@ -106,6 +112,9 @@ func ask(msg, def string) string {
 }
 
 func askRequired(msg string) string {
+	if yesFlag {
+		log.Fatalf("missing required input for: %s (cannot auto-fill)", msg)
+	}
 	for {
 		fmt.Printf("%s: ", msg)
 		t, _ := reader.ReadString('\n')
@@ -117,6 +126,10 @@ func askRequired(msg string) string {
 }
 
 func askYesNo(msg string, def bool) bool {
+	if yesFlag {
+		fmt.Printf("%s [%s]: %v\n", msg, map[bool]string{true: "yes", false: "no"}[def], def)
+		return def
+	}
 	defStr := "yes"
 	if !def {
 		defStr = "no"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a non-interactive installation mode using the `-yes` flag to automatically confirm prompts.
* **Documentation**
  * Updated the README with instructions for non-interactive installation, detailed usage examples, and a comprehensive table of command-line flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->