### PR TITLE
feat(network): add --override-interface to force the default-route device

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,17 @@ boot-to-talos -yes -disk /dev/sda -image ghcr.io/cozystack/cozystack/talos:v1.10
 | `-image string`       | Talos image (container ref, ISO path, RAW path, or HTTP URL)       | `-image ghcr.io/cozystack/cozystack/talos:v1.11` |
 | `-image-size-gib uint`| Size of image.raw in GiB (default: 3)                              | `-image-size-gib 4`                             |
 | `-extra-kernel-arg value` | Extra kernel argument (can be repeated)                        | `-extra-kernel-arg "console=ttyS0"`             |
+| `-override-interface string` | Override the network interface used to generate the Talos kernel cmdline `ip=`/`vlan=` args (does not affect the tool's own network I/O). Pass a VLAN / bond child interface name when the netlink probe picks the wrong device, especially with `-yes`. | `-override-interface eth0.10` |
 
 **Tip:** All flags can be combined. If a flag is not provided, the installer will prompt for input (unless `-yes` is used).
+
+### Overriding the network interface
+
+The default-route interface is auto-detected from netlink and `/proc/net/route`. On hosts where the auto-detection picks the wrong device — most commonly a VLAN sub-interface or a bond child — pass `-override-interface` to force the kernel-args generator to use a specific link. This is the recommended escape hatch for non-interactive (`-yes`) installs over VLAN:
+
+```console
+boot-to-talos -yes -mode install -disk /dev/sda -override-interface eth0.10
+```
 
 ---
 

--- a/cmd/boot-to-talos/main.go
+++ b/cmd/boot-to-talos/main.go
@@ -19,9 +19,10 @@ import (
 
 //nolint:gochecknoglobals
 var (
-	imageFlag string
-	diskFlag  string
-	modeFlag  string
+	imageFlag         string
+	diskFlag          string
+	modeFlag          string
+	overrideIfaceFlag string
 )
 
 func init() {
@@ -30,6 +31,10 @@ func init() {
 	flag.StringVar(&diskFlag, "disk", "", "target disk (will be wiped)")
 	flag.BoolVar(&cli.YesFlag, "yes", false, "automatic yes to prompts")
 	flag.StringVar(&modeFlag, "mode", "", "mode: boot or install")
+	flag.StringVar(&overrideIfaceFlag, "override-interface", "",
+		"override the network interface used to generate the Talos kernel "+
+			"cmdline ip=/vlan= args (does not affect the tool's own network I/O); "+
+			"pass the VLAN/bond child interface name when autodetect picks the wrong device")
 }
 
 func main() {
@@ -70,7 +75,7 @@ func main() {
 	}
 
 	// Collect kernel args for both modes.
-	for _, e := range network.CollectKernelArgs() {
+	for _, e := range network.CollectKernelArgs(overrideIfaceFlag) {
 		extra = append(extra, e)
 	}
 

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/cockroachdb/errors"
@@ -444,7 +445,12 @@ func LACPRateToString(rate uint8) string {
 
 // GenerateBondCmdline generates kernel cmdline for bond configuration.
 // Format: bond=<bondname>:<slaves>:<options>
-func GenerateBondCmdline(info *NetworkInfo, bond *LinkInfo, bondName string) string {
+//
+// When verbatim is true, slave names are emitted as-is (skipping the
+// perm_addr-based PrettyName rewrite) — used on the --override-interface path
+// so the entire cmdline carries user-supplied names instead of partially
+// rewriting slaves into enx<mac>-style names.
+func GenerateBondCmdline(info *NetworkInfo, bond *LinkInfo, bondName string, verbatim bool) string {
 	if bond == nil || !bond.IsBond() || bond.BondMaster == nil {
 		return ""
 	}
@@ -455,10 +461,16 @@ func GenerateBondCmdline(info *NetworkInfo, bond *LinkInfo, bondName string) str
 		return ""
 	}
 
-	// Build slave list using predictable names
+	// Build slave list. Under verbatim mode the user has signed off on the
+	// link names already (override is active), so do not run them through
+	// PrettyName.
 	var slaveNames []string
 	for _, slave := range slaves {
-		slaveNames = append(slaveNames, PrettyName(slave.Name))
+		if verbatim {
+			slaveNames = append(slaveNames, slave.Name)
+		} else {
+			slaveNames = append(slaveNames, prettyNameFn(slave.Name))
+		}
 	}
 
 	// Build options
@@ -641,32 +653,87 @@ func GetHostname() string {
 	return hostname
 }
 
-// CollectKernelArgs collects kernel arguments for network configuration.
-func CollectKernelArgs() []string {
+// Injected helpers — package-level vars so tests can swap real OS-backed
+// lookups for stubs without standing up a netlink runtime. fatalf wraps
+// log.Fatalf so tests can intercept process-terminating failures (e.g. the
+// fail-loud guard on -yes + override + missing-IPv4).
+//
+//nolint:gochecknoglobals
+var (
+	defaultRouteFn       = DefaultRoute
+	ifaceAddrFn          = IfaceAddr
+	prettyNameFn         = PrettyName
+	collectNetworkInfoFn = CollectNetworkInfo
+	fatalf               = log.Fatalf
+)
+
+// CollectKernelArgs collects networking-related kernel cmdline arguments.
+// overrideIface, when non-empty, replaces the auto-detected default-route
+// device — the escape hatch for VLAN / bond topologies where the netlink
+// or /proc/net/route probe does not converge on the right child interface.
+// Both detection paths honour the override.
+func CollectKernelArgs(overrideIface string) []string {
 	// Try netlink-based detection first (supports bond/bridge)
-	if args := collectKernelArgsNetlink(); args != nil {
+	if args := collectKernelArgsNetlink(overrideIface); args != nil {
 		return args
 	}
 
 	// Fallback to simple detection
-	return collectKernelArgsSimple()
+	return collectKernelArgsSimple(overrideIface)
+}
+
+// pickInterface returns the network device to use, plus a bool indicating
+// whether the override path was taken. Extracted so the override-vs-detect
+// decision is unit-testable without a netlink runtime.
+func pickInterface(override, detected string) (dev string, fromOverride bool) {
+	if override != "" {
+		return override, true
+	}
+	return detected, false
+}
+
+// vlanParentName resolves the cmdline name of a VLAN's parent link. When
+// fromOverride is true, raw link names are used (skipping the perm_addr-based
+// PrettyName rewrite) so a user override reaches the kernel cmdline verbatim.
+// When the parent is a bond that matches the active actualDevice, the
+// caller-supplied bondName is preferred so the cmdline references whatever
+// the bond block named the master.
+func vlanParentName(parent, actualDevice *LinkInfo, bondName string, fromOverride bool) string {
+	if parent == nil {
+		return "unknown"
+	}
+	if parent.IsBond() && actualDevice != nil && actualDevice.IsBond() {
+		return bondName
+	}
+	if fromOverride {
+		return parent.Name
+	}
+	return prettyNameFn(parent.Name)
 }
 
 //nolint:gocognit,forbidigo,funlen
-func collectKernelArgsNetlink() []string {
+func collectKernelArgsNetlink(overrideIface string) []string {
 	// Try to collect network info via netlink
-	netInfo, err := CollectNetworkInfo()
+	netInfo, err := collectNetworkInfoFn()
 	if err != nil {
 		log.Printf("warning: failed to collect network info via netlink: %v", err)
 		log.Printf("falling back to simple detection")
 		return nil // Will use fallback
 	}
 
-	// Find default route interface
-	dev, gw, err := DefaultRoute()
-	if err != nil {
-		log.Printf("warning: no default route found: %v", err)
+	// Find default route interface, honouring the override when set.
+	detectedDev, gw, drErr := defaultRouteFn()
+	dev, fromOverride := pickInterface(overrideIface, detectedDev)
+	if !fromOverride && drErr != nil {
+		log.Printf("warning: no default route found: %v", drErr)
 		return nil
+	}
+	if fromOverride {
+		log.Printf("using override interface %s (auto-detected was %q, default route err=%v)",
+			dev, detectedDev, drErr)
+		if drErr != nil {
+			log.Printf("warning: no default route — gateway will be empty unless answered interactively")
+		}
 	}
 
 	// Get link info for the interface
@@ -686,9 +753,14 @@ func collectKernelArgsNetlink() []string {
 	}
 
 	// Get IP address and mask
-	ip, mask, err := IfaceAddr(dev)
+	ip, mask, err := ifaceAddrFn(dev)
 	if err != nil {
-		log.Printf("warning: failed to get IP address for %s: %v", dev, err)
+		if fromOverride {
+			log.Printf("warning: failed to read IPv4 address for override interface %q: %v "+
+				"— falling back to simple detection", dev, err)
+		} else {
+			log.Printf("warning: failed to get IP address for %s: %v", dev, err)
+		}
 		return nil
 	}
 
@@ -704,7 +776,15 @@ func collectKernelArgsNetlink() []string {
 	// If there's a VLAN, the IP goes on the VLAN interface
 	// If there's a bond, the IP goes on the bond (or VLAN on bond)
 	var ipDevice string
+	// Default bond master name in the kernel cmdline. When fromOverride is
+	// true and the override resolves to a bond master, replace this with
+	// the override so the bond=/ip= lines stay internally consistent
+	// (otherwise the kernel would create "bond0" from the bond= line while
+	// the ip= line points at a non-existent override name).
 	bondName := "bond0"
+	if fromOverride && actualDevice.IsBond() {
+		bondName = actualDevice.Name
+	}
 
 	// Handle bond
 	if actualDevice.IsBond() {
@@ -716,7 +796,7 @@ func collectKernelArgsNetlink() []string {
 				if i > 0 {
 					fmt.Printf(", ")
 				}
-				fmt.Printf("%s (%s)", s.Name, PrettyName(s.Name))
+				fmt.Printf("%s (%s)", s.Name, prettyNameFn(s.Name))
 			}
 			fmt.Println()
 		}
@@ -729,15 +809,28 @@ func collectKernelArgsNetlink() []string {
 		}
 
 		// Generate bond cmdline
-		bondCmdline := GenerateBondCmdline(netInfo, actualDevice, bondName)
+		bondCmdline := GenerateBondCmdline(netInfo, actualDevice, bondName, fromOverride)
 		if bondCmdline != "" {
 			out = append(out, bondCmdline)
 		}
-		ipDevice = bondName
+		if fromOverride {
+			ipDevice = overrideIface
+			fmt.Printf("Bond IP device: %s (override active, bond master = %s)\n", ipDevice, bondName)
+		} else {
+			ipDevice = bondName
+		}
 	} else {
-		// Regular interface
-		ipDevice = PrettyName(actualDevice.Name)
-		fmt.Printf("\nDetected interface: %s (%s)\n", actualDevice.Name, ipDevice)
+		// Regular interface. Skip the perm_addr-based rewrite for an
+		// explicit override so the user-supplied name (often a VLAN child)
+		// reaches the kernel cmdline verbatim.
+		if fromOverride {
+			ipDevice = overrideIface
+			fmt.Printf("\nDetected interface: %s (override active, using %s verbatim)\n",
+				actualDevice.Name, overrideIface)
+		} else {
+			ipDevice = prettyNameFn(actualDevice.Name)
+			fmt.Printf("\nDetected interface: %s (%s)\n", actualDevice.Name, ipDevice)
+		}
 	}
 
 	// Handle VLANs
@@ -746,14 +839,11 @@ func collectKernelArgsNetlink() []string {
 		for _, vlan := range vlans {
 			if vlan.VLAN != nil {
 				parent := netInfo.GetLinkByIndex(vlan.LinkIndex)
-				parentName := "unknown"
-				if parent != nil {
-					if parent.IsBond() && actualDevice.IsBond() {
-						parentName = bondName
-					} else {
-						parentName = PrettyName(parent.Name)
-					}
-				}
+				// Display name matches what the cmdline will carry — route
+				// through the same vlanParentName helper used below so the
+				// human-readable preamble does not diverge from the emitted
+				// vlan=/ip= lines under override.
+				parentName := vlanParentName(parent, actualDevice, bondName, fromOverride)
 				fmt.Printf("  VLAN %d on %s (interface: %s)\n", vlan.VLAN.VID, parentName, vlan.Name)
 			}
 		}
@@ -761,29 +851,30 @@ func collectKernelArgsNetlink() []string {
 
 		// Generate VLAN cmdlines (in reverse order - from lowest to topmost)
 		// This ensures parent interfaces are created before child VLANs
-		for i := len(vlans) - 1; i >= 0; i-- {
-			vlan := vlans[i]
+		for i, vlan := range slices.Backward(vlans) {
 			if vlan.VLAN == nil {
 				continue
 			}
 
-			// Determine VLAN device name for Talos
-			// Format: <parent>.<vid>
+			// Determine VLAN device name for Talos.
+			// When fromOverride, names go through verbatim (no PrettyName
+			// rewrite) so the user-supplied leaf reaches the kernel cmdline
+			// unchanged. Format: <parent>.<vid>.
 			parent := netInfo.GetLinkByIndex(vlan.LinkIndex)
-			var parentName string
-			if parent != nil {
-				if parent.IsBond() && actualDevice.IsBond() {
-					parentName = bondName
-				} else if parent.IsVLAN() {
-					// Nested VLAN - find the previous VLAN's name
-					// For now, use predictable name
-					parentName = PrettyName(parent.Name)
-				} else {
-					parentName = PrettyName(parent.Name)
-				}
-			}
+			parentName := vlanParentName(parent, actualDevice, bondName, fromOverride)
 
 			vlanName := fmt.Sprintf("%s.%d", parentName, vlan.VLAN.VID)
+			// The topmost VLAN (i == 0 after Backward) is the leaf — if an
+			// override is active, honour the user-supplied name verbatim
+			// rather than the derived <parent>.<vid> form. For the common
+			// case where the user passes "eth0.10" the two forms agree, but
+			// this branch covers the rarer case where the runtime link name
+			// does not follow the dotted convention (e.g. ifrename'd VLAN
+			// interfaces) and the user is telling us the exact kernel name
+			// they expect on the cmdline.
+			if i == 0 && fromOverride {
+				vlanName = overrideIface
+			}
 			vlanCmdline := fmt.Sprintf("vlan=%s:%s", vlanName, parentName)
 			out = append(out, vlanCmdline)
 
@@ -820,10 +911,36 @@ func collectKernelArgsNetlink() []string {
 	return out
 }
 
-func collectKernelArgsSimple() []string {
-	dev, gw, _ := DefaultRoute()
-	ip, mask, _ := IfaceAddr(dev)
-	dev = PrettyName(dev)
+func collectKernelArgsSimple(overrideIface string) []string {
+	detectedDev, gw, drErr := defaultRouteFn()
+	dev, fromOverride := pickInterface(overrideIface, detectedDev)
+	if fromOverride {
+		log.Printf("using override interface %s (auto-detected was %q)", dev, detectedDev)
+		if drErr != nil {
+			log.Printf("warning: no default route — gateway will be empty unless answered interactively")
+		}
+	}
+	ip, mask, ifErr := ifaceAddrFn(dev)
+	if fromOverride && ifErr != nil {
+		if cli.YesFlag {
+			// Non-interactive caller asked for an override interface that
+			// has no IPv4 address; emitting an ip= line with empty fields
+			// would silently produce a broken Talos install. Fail loudly
+			// so the operator sees the problem now, not after a reboot
+			// into a node without networking.
+			fatalf("override interface %q has no IPv4 address: %v "+
+				"(refusing to emit a broken ip= line under -yes)", dev, ifErr)
+		}
+		log.Printf("warning: failed to read IPv4 address for override interface %q: %v "+
+			"— ip/mask will be empty unless answered interactively", dev, ifErr)
+	}
+	// Skip the perm_addr-based rewrite for an explicit override: the user
+	// passed a specific interface name (often a VLAN child like eth0.10
+	// that inherits its parent's MAC) and the kernel cmdline must carry
+	// that exact name.
+	if !fromOverride {
+		dev = prettyNameFn(dev)
+	}
 	hostname := GetHostname()
 
 	netOn := cli.AskYesNo("Add networking configuration?", true)

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -1,0 +1,550 @@
+//go:build linux
+
+package network
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+
+	"github.com/cozystack/boot-to-talos/internal/cli"
+)
+
+func TestPickInterface(t *testing.T) {
+	tests := []struct {
+		name             string
+		override         string
+		detected         string
+		wantDev          string
+		wantFromOverride bool
+	}{
+		{
+			name:             "no override, detected used",
+			override:         "",
+			detected:         "eth0",
+			wantDev:          "eth0",
+			wantFromOverride: false,
+		},
+		{
+			name:             "override wins over detected",
+			override:         "eth0.4000",
+			detected:         "eth0",
+			wantDev:          "eth0.4000",
+			wantFromOverride: true,
+		},
+		{
+			name:             "override wins even when detection failed",
+			override:         "bond0",
+			detected:         "",
+			wantDev:          "bond0",
+			wantFromOverride: true,
+		},
+		{
+			name:             "empty override, empty detected, both empty",
+			override:         "",
+			detected:         "",
+			wantDev:          "",
+			wantFromOverride: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dev, fromOverride := pickInterface(tt.override, tt.detected)
+			if dev != tt.wantDev {
+				t.Errorf("dev = %q, want %q", dev, tt.wantDev)
+			}
+			if fromOverride != tt.wantFromOverride {
+				t.Errorf("fromOverride = %v, want %v", fromOverride, tt.wantFromOverride)
+			}
+		})
+	}
+}
+
+// swapFns swaps the package-level injected helpers for the duration of the
+// test, restoring originals via t.Cleanup. Keeps individual tests focused on
+// the override behaviour rather than the injection mechanics. NOT safe under
+// t.Parallel — the helpers mutate package globals; if a future test enables
+// parallelism, gate the swaps behind a sync.Mutex.
+func swapFns(t *testing.T, dr func() (string, string, error), ia func(string) (string, string, error), pn func(string) string) {
+	t.Helper()
+	origDR, origIA, origPN := defaultRouteFn, ifaceAddrFn, prettyNameFn
+	defaultRouteFn = dr
+	ifaceAddrFn = ia
+	prettyNameFn = pn
+	t.Cleanup(func() {
+		defaultRouteFn = origDR
+		ifaceAddrFn = origIA
+		prettyNameFn = origPN
+	})
+}
+
+// swapNetInfo swaps collectNetworkInfoFn for the duration of the test.
+func swapNetInfo(t *testing.T, fn func() (*NetworkInfo, error)) {
+	t.Helper()
+	orig := collectNetworkInfoFn
+	collectNetworkInfoFn = fn
+	t.Cleanup(func() { collectNetworkInfoFn = orig })
+}
+
+// buildNetInfo constructs a NetworkInfo from a flat list of LinkInfo values,
+// initialising the private linkIndex / linkName maps that GetLinkByIndex /
+// GetLinkByName rely on. Tests use this to assemble VLAN / bond topologies
+// without standing up real netlink.
+func buildNetInfo(links []LinkInfo) *NetworkInfo {
+	info := &NetworkInfo{
+		Links:     links,
+		linkIndex: make(map[uint32]*LinkInfo),
+		linkName:  make(map[string]*LinkInfo),
+	}
+	for i := range info.Links {
+		l := &info.Links[i]
+		info.linkIndex[l.Index] = l
+		info.linkName[l.Name] = l
+	}
+	return info
+}
+
+// withYes flips cli.YesFlag for the duration of the test and restores it.
+// Required because collectKernelArgsSimple consults cli.AskYesNo / cli.Ask,
+// which only return defaults when YesFlag is set.
+func withYes(t *testing.T) {
+	t.Helper()
+	orig := cli.YesFlag
+	cli.YesFlag = true
+	t.Cleanup(func() { cli.YesFlag = orig })
+}
+
+// captureLog redirects the standard logger to a buffer for assertion on
+// log output (used by the empty-gateway warning test).
+func captureLog(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	origOut := log.Writer()
+	origFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(origOut)
+		log.SetFlags(origFlags)
+	})
+	return &buf
+}
+
+func TestCollectKernelArgsSimple_OverrideBypassesPrettyName(t *testing.T) {
+	withYes(t)
+	swapFns(t,
+		// DefaultRoute reports the parent NIC as default.
+		func() (string, string, error) { return "eth0", "192.168.1.1", nil },
+		// IfaceAddr returns an address only for the VLAN child.
+		func(dev string) (string, string, error) {
+			if dev == "eth0.10" {
+				return "10.0.0.5", "255.255.255.0", nil
+			}
+			return "", "", errors.New("no IPv4")
+		},
+		// PrettyName must NOT be called for an override; if it is, force a
+		// visibly-wrong result so the test fails loudly.
+		func(string) string { return "POISONED" },
+	)
+
+	out := collectKernelArgsSimple("eth0.10")
+
+	var ipLine string
+	for _, a := range out {
+		if strings.HasPrefix(a, "ip=") {
+			ipLine = a
+		}
+	}
+	if ipLine == "" {
+		t.Fatalf("collectKernelArgsSimple returned no ip= line; got %v", out)
+	}
+	if strings.Contains(ipLine, "POISONED") {
+		t.Errorf("ip= line was rewritten by PrettyName despite override: %q", ipLine)
+	}
+	if !strings.Contains(ipLine, ":eth0.10:") {
+		t.Errorf("ip= line missing override device name: %q", ipLine)
+	}
+	if !strings.Contains(ipLine, "10.0.0.5") {
+		t.Errorf("ip= line missing override-interface address: %q", ipLine)
+	}
+}
+
+func TestCollectKernelArgsSimple_NoOverrideUsesPrettyName(t *testing.T) {
+	withYes(t)
+	swapFns(t,
+		func() (string, string, error) { return "eth0", "192.168.1.1", nil },
+		func(string) (string, string, error) { return "192.168.1.42", "255.255.255.0", nil },
+		// Standard predictable-name rewrite for non-override path.
+		func(string) string { return "enp0s31f6" },
+	)
+
+	out := collectKernelArgsSimple("")
+
+	var ipLine string
+	for _, a := range out {
+		if strings.HasPrefix(a, "ip=") {
+			ipLine = a
+		}
+	}
+	if !strings.Contains(ipLine, ":enp0s31f6:") {
+		t.Errorf("ip= line missing predictable name: %q", ipLine)
+	}
+}
+
+// TestCollectKernelArgsNetlink_OverrideVLANChildBypassesPrettyName proves that
+// when the user passes a VLAN-child override, the netlink path emits the
+// override verbatim in both the leaf ip=...:<dev>:none and the vlan= cmdline,
+// and crucially does NOT route the parent name through PrettyName (which would
+// rewrite eth0 → enx<mac> and break the kernel's link lookup).
+func TestCollectKernelArgsNetlink_OverrideVLANChildBypassesPrettyName(t *testing.T) {
+	withYes(t)
+	eth0 := LinkInfo{Name: "eth0", Index: 1, Kind: ""}
+	vlan := LinkInfo{
+		Name:      "eth0.10",
+		Index:     2,
+		LinkIndex: 1,
+		Kind:      "vlan",
+		VLAN:      &VLANSpec{VID: 10, Protocol: 0x8100},
+	}
+	swapNetInfo(t, func() (*NetworkInfo, error) {
+		return buildNetInfo([]LinkInfo{eth0, vlan}), nil
+	})
+	swapFns(t,
+		func() (string, string, error) { return "eth0", "192.168.1.1", nil },
+		func(dev string) (string, string, error) {
+			if dev == "eth0.10" {
+				return "10.0.0.5", "255.255.255.0", nil
+			}
+			return "", "", errors.New("no IPv4")
+		},
+		func(string) string { return "POISONED" },
+	)
+
+	out := collectKernelArgsNetlink("eth0.10")
+	if out == nil {
+		t.Fatal("collectKernelArgsNetlink returned nil for override; expected cmdline")
+	}
+	joined := strings.Join(out, " ")
+	if strings.Contains(joined, "POISONED") {
+		t.Errorf("netlink path used PrettyName on override path: %q", joined)
+	}
+	if !strings.Contains(joined, "ip=") || !strings.Contains(joined, ":eth0.10:none") {
+		t.Errorf("ip= line missing override leaf %q in: %q", "eth0.10", joined)
+	}
+	if !strings.Contains(joined, "vlan=eth0.10:eth0") {
+		t.Errorf("vlan= cmdline missing expected eth0.10:eth0 in: %q", joined)
+	}
+}
+
+// TestCollectKernelArgsNetlink_OverrideBondNameStaysConsistent proves the
+// emitted bond= and ip= lines reference the same master name when the bond
+// happens to be called something other than "bond0" and the user overrides
+// to that real name. With actual slaves present GenerateBondCmdline emits a
+// non-empty bond= line, so this test validates the full internal-consistency
+// invariant: whatever appears in :DEV:none of ip= must also appear as the
+// master name in the bond= line.
+func TestCollectKernelArgsNetlink_OverrideBondNameStaysConsistent(t *testing.T) {
+	withYes(t)
+	bond := LinkInfo{
+		Name:       "team0",
+		Index:      1,
+		Kind:       "bond",
+		BondMaster: &BondMasterSpec{Mode: BondModeBalanceRR, MIIMon: 100},
+	}
+	slave1 := LinkInfo{
+		Name:        "eth0",
+		Index:       2,
+		MasterIndex: 1,
+		SlaveKind:   "bond",
+	}
+	slave2 := LinkInfo{
+		Name:        "eth1",
+		Index:       3,
+		MasterIndex: 1,
+		SlaveKind:   "bond",
+	}
+	swapNetInfo(t, func() (*NetworkInfo, error) {
+		return buildNetInfo([]LinkInfo{bond, slave1, slave2}), nil
+	})
+	swapFns(t,
+		func() (string, string, error) { return "team0", "192.168.1.1", nil },
+		func(dev string) (string, string, error) {
+			if dev == "team0" {
+				return "10.0.0.5", "255.255.255.0", nil
+			}
+			return "", "", errors.New("no IPv4")
+		},
+		func(string) string { return "POISONED" },
+	)
+
+	out := collectKernelArgsNetlink("team0")
+	if out == nil {
+		t.Fatal("collectKernelArgsNetlink returned nil; expected cmdline")
+	}
+	joined := strings.Join(out, " ")
+
+	var bondLine, ipLine string
+	for _, a := range out {
+		switch {
+		case strings.HasPrefix(a, "bond="):
+			bondLine = a
+		case strings.HasPrefix(a, "ip="):
+			ipLine = a
+		}
+	}
+	if bondLine == "" {
+		t.Fatalf("no bond= line emitted; got %v", out)
+	}
+	if !strings.HasPrefix(bondLine, "bond=team0:") {
+		t.Errorf("bond= master name not overridden: %q", bondLine)
+	}
+	if !strings.Contains(ipLine, ":team0:none") {
+		t.Errorf("ip= line did not carry override device name: %q", ipLine)
+	}
+	if strings.Contains(joined, "bond=bond0") || strings.Contains(joined, ":bond0:") {
+		t.Errorf("hardcoded bond0 leaked into cmdline despite override: %q", joined)
+	}
+	if strings.Contains(joined, "POISONED") {
+		t.Errorf("PrettyName leaked into cmdline on override path: %q", joined)
+	}
+}
+
+// TestCollectKernelArgsNetlink_OverrideRenamedVLANUsesUserName proves the
+// fromOverride leaf-name branch: when the live link name does not follow the
+// <parent>.<vid> convention (ifrename'd VLAN), the cmdline must carry the
+// user-supplied override verbatim, not a derived <parent>.<vid> form.
+func TestCollectKernelArgsNetlink_OverrideRenamedVLANUsesUserName(t *testing.T) {
+	withYes(t)
+	eth0 := LinkInfo{Name: "eth0", Index: 1, Kind: ""}
+	vlan := LinkInfo{
+		Name:      "myvlan",
+		Index:     2,
+		LinkIndex: 1,
+		Kind:      "vlan",
+		VLAN:      &VLANSpec{VID: 10, Protocol: 0x8100},
+	}
+	swapNetInfo(t, func() (*NetworkInfo, error) {
+		return buildNetInfo([]LinkInfo{eth0, vlan}), nil
+	})
+	swapFns(t,
+		func() (string, string, error) { return "eth0", "192.168.1.1", nil },
+		func(dev string) (string, string, error) {
+			if dev == "myvlan" {
+				return "10.0.0.5", "255.255.255.0", nil
+			}
+			return "", "", errors.New("no IPv4")
+		},
+		func(string) string { return "POISONED" },
+	)
+
+	out := collectKernelArgsNetlink("myvlan")
+	if out == nil {
+		t.Fatal("collectKernelArgsNetlink returned nil; expected cmdline")
+	}
+	joined := strings.Join(out, " ")
+	if !strings.Contains(joined, "vlan=myvlan:eth0") {
+		t.Errorf("vlan= line did not use override name verbatim: %q", joined)
+	}
+	if strings.Contains(joined, "eth0.10") {
+		t.Errorf("derived <parent>.<vid> name leaked into cmdline despite ifrename override: %q", joined)
+	}
+	if !strings.Contains(joined, ":myvlan:none") {
+		t.Errorf("ip= line did not carry override leaf: %q", joined)
+	}
+}
+
+// TestCollectKernelArgsNetlink_OverrideBondSlaveNamesAreVerbatim pins the
+// bond= line slave-naming invariant on the override path: slaves go through
+// the injected prettyNameFn under no-override, but stay raw under override so
+// the entire emitted cmdline is internally consistent.
+func TestCollectKernelArgsNetlink_OverrideBondSlaveNamesAreVerbatim(t *testing.T) {
+	withYes(t)
+	bond := LinkInfo{
+		Name:       "team0",
+		Index:      1,
+		Kind:       "bond",
+		BondMaster: &BondMasterSpec{Mode: BondModeBalanceRR, MIIMon: 100},
+	}
+	s1 := LinkInfo{Name: "eth0", Index: 2, MasterIndex: 1, SlaveKind: "bond"}
+	s2 := LinkInfo{Name: "eth1", Index: 3, MasterIndex: 1, SlaveKind: "bond"}
+	swapNetInfo(t, func() (*NetworkInfo, error) {
+		return buildNetInfo([]LinkInfo{bond, s1, s2}), nil
+	})
+	swapFns(t,
+		func() (string, string, error) { return "team0", "192.168.1.1", nil },
+		func(dev string) (string, string, error) {
+			if dev == "team0" {
+				return "10.0.0.5", "255.255.255.0", nil
+			}
+			return "", "", errors.New("no IPv4")
+		},
+		// PrettyName must not appear in the bond= line under override.
+		func(string) string { return "POISONED" },
+	)
+
+	out := collectKernelArgsNetlink("team0")
+	if out == nil {
+		t.Fatal("collectKernelArgsNetlink returned nil; expected cmdline")
+	}
+	joined := strings.Join(out, " ")
+	if !strings.Contains(joined, "bond=team0:eth0,eth1:") {
+		t.Errorf("bond= line did not emit raw slave names under override: %q", joined)
+	}
+	if strings.Contains(joined, "POISONED") {
+		t.Errorf("PrettyName leaked into bond slave names despite override: %q", joined)
+	}
+}
+
+// TestCollectKernelArgsSimple_FailLoudUnderYesOverrideMissingIP pins the
+// non-interactive-install safety guard: -yes + override + missing IPv4 must
+// surface a fatal error rather than silently emit ip=::<gw>:::<dev>:none.
+func TestCollectKernelArgsSimple_FailLoudUnderYesOverrideMissingIP(t *testing.T) {
+	withYes(t)
+	swapFns(t,
+		func() (string, string, error) { return "eth0", "192.168.1.1", nil },
+		func(string) (string, string, error) { return "", "", errors.New("no IPv4") },
+		func(string) string { return "POISONED" },
+	)
+
+	origFatal := fatalf
+	var fatalMsg string
+	fatalf = func(format string, args ...any) {
+		fatalMsg = sprintf(format, args...)
+		panic(fatalSentinel{})
+	}
+	defer func() { fatalf = origFatal }()
+
+	defer func() {
+		r := recover()
+		if _, ok := r.(fatalSentinel); !ok {
+			t.Fatalf("expected fatalSentinel panic; got recover()=%v", r)
+		}
+		if !strings.Contains(fatalMsg, `override interface "eth0.999"`) {
+			t.Errorf("fatal message missing override identifier: %q", fatalMsg)
+		}
+	}()
+
+	_ = collectKernelArgsSimple("eth0.999")
+}
+
+// fatalSentinel is the panic value emitted by the test's fatalf stub. Using
+// a typed sentinel (rather than an error) lets the fail-loud test
+// distinguish its own panic from any unrelated runtime panic without
+// tripping err113.
+type fatalSentinel struct{}
+
+func sprintf(format string, args ...any) string {
+	return fmt.Sprintf(format, args...)
+}
+
+// TestCollectKernelArgsNetlink_OverrideMissingInterfaceWarns mirrors the
+// simple-path test of the same shape: when the override interface has no
+// IPv4 address, the netlink path must surface a warning that names the
+// override (not the generic "failed to get IP address" message) before
+// returning nil to fall back to the simple path.
+func TestCollectKernelArgsNetlink_OverrideMissingInterfaceWarns(t *testing.T) {
+	withYes(t)
+	buf := captureLog(t)
+	link := LinkInfo{Name: "eth0.999", Index: 1, Kind: "vlan", VLAN: &VLANSpec{VID: 999}}
+	swapNetInfo(t, func() (*NetworkInfo, error) {
+		return buildNetInfo([]LinkInfo{link}), nil
+	})
+	swapFns(t,
+		func() (string, string, error) { return "eth0", "192.168.1.1", nil },
+		func(string) (string, string, error) { return "", "", errors.New("no IPv4") },
+		func(string) string { return "POISONED" },
+	)
+
+	if out := collectKernelArgsNetlink("eth0.999"); out != nil {
+		t.Errorf("netlink path returned %v under missing-IP override; expected nil so simple path runs", out)
+	}
+	if !strings.Contains(buf.String(), `override interface "eth0.999"`) {
+		t.Errorf("expected override-specific warning naming eth0.999; got %q", buf.String())
+	}
+}
+
+// TestVLANParentName covers the helper directly: bond match wins over
+// override; otherwise override returns the raw parent name while no-override
+// goes through the injected PrettyName.
+func TestVLANParentName(t *testing.T) {
+	swapFns(t,
+		func() (string, string, error) { return "", "", nil },
+		func(string) (string, string, error) { return "", "", nil },
+		func(string) string { return "PRETTY" },
+	)
+	bond := &LinkInfo{Name: "bond0", Kind: "bond"}
+	eth := &LinkInfo{Name: "eth0"}
+
+	if got := vlanParentName(bond, bond, "bond0", false); got != "bond0" {
+		t.Errorf("bond parent: got %q, want bond0", got)
+	}
+	if got := vlanParentName(eth, eth, "bond0", true); got != "eth0" {
+		t.Errorf("override path returns raw name: got %q, want eth0", got)
+	}
+	if got := vlanParentName(eth, eth, "bond0", false); got != "PRETTY" {
+		t.Errorf("non-override path goes through PrettyName: got %q, want PRETTY", got)
+	}
+	if got := vlanParentName(nil, eth, "bond0", false); got != "unknown" {
+		t.Errorf("nil parent: got %q, want unknown", got)
+	}
+}
+
+// TestCollectKernelArgsSimple_InteractiveOverrideMissingIPWarns covers the
+// non-fatal path: with YesFlag disabled the simple path must still log a
+// specific warning naming the override interface (operator answers ip/mask
+// interactively).
+func TestCollectKernelArgsSimple_InteractiveOverrideMissingIPWarns(t *testing.T) {
+	// Note: cli.YesFlag stays false here — the fail-loud guard only fires
+	// under -yes; in interactive mode we want a warning and a prompt.
+	buf := captureLog(t)
+	swapFns(t,
+		func() (string, string, error) { return "eth0", "192.168.1.1", nil },
+		func(string) (string, string, error) { return "", "", errors.New("no IPv4") },
+		func(string) string { return "POISONED" },
+	)
+
+	// Override fatalf so the interactive path that drains stdin via cli.Ask
+	// does not block the test; the helper returns nothing on EOF.
+	origFatal := fatalf
+	fatalf = func(string, ...any) {}
+	defer func() { fatalf = origFatal }()
+
+	_ = collectKernelArgsSimple("eth0.999")
+
+	if !strings.Contains(buf.String(), "failed to read IPv4 address for override interface") {
+		t.Errorf("expected warning about override interface; got %q", buf.String())
+	}
+}
+
+func TestCollectKernelArgsSimple_OverrideEmptyGatewayWarns(t *testing.T) {
+	withYes(t)
+	buf := captureLog(t)
+	swapFns(t,
+		func() (string, string, error) {
+			return "", "", errors.New("no default route")
+		},
+		func(string) (string, string, error) { return "10.0.0.5", "255.255.255.0", nil },
+		func(string) string { return "POISONED" },
+	)
+
+	out := collectKernelArgsSimple("eth0.10")
+
+	logged := buf.String()
+	if !strings.Contains(logged, "gateway will be empty") {
+		t.Errorf("expected empty-gateway warning in log; got %q", logged)
+	}
+	var ipLine string
+	for _, a := range out {
+		if strings.HasPrefix(a, "ip=") {
+			ipLine = a
+		}
+	}
+	if !strings.Contains(ipLine, ":eth0.10:") {
+		t.Errorf("override device missing from ip= line: %q", ipLine)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-override-interface` CLI flag to override the network interface used for Talos kernel configuration generation, independently of the tool's own network I/O. Useful for VLAN and bonded interface scenarios.

* **Documentation**
  * Documented the new override interface flag with examples and use-case guidance in README.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cozystack/boot-to-talos/pull/12)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->