### PR TITLE
fix(efi): create boot entry from target disk instead of relying on installer

### DIFF
--- a/internal/efi/efi.go
+++ b/internal/efi/efi.go
@@ -11,11 +11,14 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"unsafe"
 
 	"github.com/cockroachdb/errors"
+	"github.com/diskfs/go-diskfs"
+	"github.com/diskfs/go-diskfs/partition/gpt"
 	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
 	"golang.org/x/text/encoding/unicode"
@@ -191,72 +194,99 @@ func GetUKIAndPartitionInfo(loopDevice, rawImage string) (string, any, error) {
 	return ukiPath, nil, nil
 }
 
-// UpdateEFIVariables updates EFI variables after installation.
-// This finds the Talos boot entry created by installer and updates BootOrder to put it first.
-func UpdateEFIVariables(disk, ukiPath string, rawBlkidInfo any) error {
-	// Create efivarfs reader/writer
+// UpdateEFIVariables creates a Talos boot entry pointing to the target disk's ESP
+// and updates BootOrder to put it first.
+func UpdateEFIVariables(disk string) error {
 	efiRW, err := newEFIReaderWriter(true)
 	if err != nil {
 		return errors.Wrap(err, "failed to create efivarfs reader/writer")
 	}
 	defer efiRW.Close()
 
-	// Get current BootOrder
-	bootOrder, err := getBootOrder(efiRW)
+	// Read GPT from target disk to find ESP
+	esp, err := getESPInfo(disk)
 	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return errors.Wrap(err, "failed to get BootOrder")
-		}
-		bootOrder = BootOrderType{}
+		return errors.Wrap(err, "failed to get ESP info from target disk")
 	}
 
-	log.Printf("Current BootOrder: %v", bootOrder)
+	log.Printf("found ESP: partition %d, start LBA %d, size %d blocks, UUID %s",
+		esp.PartitionNumber, esp.StartLBA, esp.SizeLBA, esp.PartitionGUID)
 
-	// List all boot entries to find Talos entry
+	// Determine EFI file path based on architecture
+	efiFilePath, err := sdbootFilePath()
+	if err != nil {
+		return err
+	}
+
+	// List existing boot entries to find existing Talos entry
 	bootEntries, err := listBootEntries(efiRW)
 	if err != nil {
 		return errors.Wrap(err, "failed to list boot entries")
 	}
 
-	// Find Talos boot entry index
-	talosBootEntryIndex := -1
+	// Find existing Talos entry or allocate new index
+	targetIdx := -1
 	for idx, entry := range bootEntries {
-		if entry.Description == "Talos Linux UKI" {
-			talosBootEntryIndex = idx
-			log.Printf("Found Talos boot entry at index %d", idx)
+		if entry.Description == talosBootEntryDescription {
+			targetIdx = idx
+			log.Printf("found existing Talos boot entry at index %d, will overwrite", idx)
+
 			break
 		}
 	}
 
-	if talosBootEntryIndex == -1 {
-		return errors.New("Talos boot entry not found")
-	}
-
-	// Update BootOrder: put Talos entry first, then all others (excluding Talos entries)
-	newBootOrder := BootOrderType{uint16(talosBootEntryIndex)}
-
-	// Add other entries (excluding Talos entries)
-	talosIndexSet := make(map[uint16]bool)
-	for idx := range bootEntries {
-		if bootEntries[idx].Description == "Talos Linux UKI" {
-			talosIndexSet[uint16(idx)] = true
+	if targetIdx < 0 {
+		targetIdx, err = findFreeBootIndex(efiRW)
+		if err != nil {
+			return errors.Wrap(err, "failed to find free boot index")
 		}
+
+		log.Printf("will create new boot entry at index %d", targetIdx)
 	}
+
+	// Build and write the boot entry
+	opt := &loadOption{
+		Description: talosBootEntryDescription,
+		FilePath: devicePath{
+			&hardDrivePath{
+				PartitionNumber:    esp.PartitionNumber,
+				PartitionStart:     esp.StartLBA,
+				PartitionSize:      esp.SizeLBA,
+				PartitionSignature: esp.PartitionGUID,
+			},
+			&filePathElem{Path: efiFilePath},
+			&endOfDevicePath{},
+		},
+	}
+
+	if err := setBootEntry(efiRW, targetIdx, opt); err != nil {
+		return errors.Wrapf(err, "failed to write boot entry at index %d", targetIdx)
+	}
+
+	// Update BootOrder: put new entry first, keep others without duplicates
+	bootOrder, err := getBootOrder(efiRW)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return errors.Wrap(err, "failed to get BootOrder")
+		}
+
+		bootOrder = BootOrderType{}
+	}
+
+	newBootOrder := BootOrderType{uint16(targetIdx)}
 
 	for _, idx := range bootOrder {
-		if !talosIndexSet[idx] {
+		if idx != uint16(targetIdx) {
 			newBootOrder = append(newBootOrder, idx)
 		}
 	}
 
-	log.Printf("New BootOrder: %v", newBootOrder)
-
-	// Update BootOrder
 	if err := setBootOrder(efiRW, newBootOrder); err != nil {
 		return errors.Wrap(err, "failed to set BootOrder")
 	}
 
-	log.Printf("BootOrder updated successfully, Talos entry %d is now first", talosBootEntryIndex)
+	log.Printf("EFI boot entry %04X created, BootOrder: %v", targetIdx, newBootOrder)
+
 	return nil
 }
 
@@ -501,4 +531,240 @@ func unmarshalLoadOption(data []byte) (*loadOption, error) {
 		Description: string(bytes.TrimSuffix(description, []byte{0})),
 	}
 	return opt, nil
+}
+
+const talosBootEntryDescription = "Talos Linux UKI"
+
+// loadOptionActive is the LOAD_OPTION_ACTIVE attribute bit.
+const loadOptionActive = 0x00000001
+
+func (lo *loadOption) marshal() ([]byte, error) {
+	// Encode description to UTF-16LE with null terminator
+	descBytes, err := efiEncoding.NewEncoder().Bytes([]byte(lo.Description))
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding description to UTF-16LE")
+	}
+
+	descBytes = append(descBytes, 0x00, 0x00) // null terminator
+
+	// Serialize device path elements
+	var filePathList []byte
+
+	for _, elem := range lo.FilePath {
+		elemData, err := elem.data()
+		if err != nil {
+			return nil, errors.Wrap(err, "serializing device path element")
+		}
+
+		filePathList = append(filePathList, elemData...)
+	}
+
+	// Build load option: Attributes(4) + FilePathListLength(2) + Description + FilePathList
+	buf := make([]byte, 4+2+len(descBytes)+len(filePathList))
+	binary.LittleEndian.PutUint32(buf[0:4], loadOptionActive)
+	binary.LittleEndian.PutUint16(buf[4:6], uint16(len(filePathList)))
+	copy(buf[6:], descBytes)
+	copy(buf[6+len(descBytes):], filePathList)
+
+	return buf, nil
+}
+
+// hardDrivePath represents UEFI Hard Drive Media Device Path (Type 0x04, SubType 0x01).
+type hardDrivePath struct {
+	PartitionNumber    uint32
+	PartitionStart     uint64    // in logical blocks
+	PartitionSize      uint64    // in logical blocks
+	PartitionSignature uuid.UUID // partition GUID
+}
+
+const (
+	dpTypeMedia       = 0x04
+	dpSubTypeHardDrive = 0x01
+	dpSubTypeFilePath = 0x04
+	dpTypeEnd         = 0x7F
+	dpSubTypeEnd      = 0xFF
+	hardDrivePathLen  = 42 // 4-byte header + 38-byte data
+
+	gptMBRType       = 0x02
+	gptSignatureType = 0x02
+)
+
+func (h *hardDrivePath) typ() uint8     { return dpTypeMedia }
+func (h *hardDrivePath) subType() uint8 { return dpSubTypeHardDrive }
+
+func (h *hardDrivePath) data() ([]byte, error) {
+	buf := make([]byte, hardDrivePathLen)
+	buf[0] = dpTypeMedia
+	buf[1] = dpSubTypeHardDrive
+	binary.LittleEndian.PutUint16(buf[2:4], hardDrivePathLen)
+	binary.LittleEndian.PutUint32(buf[4:8], h.PartitionNumber)
+	binary.LittleEndian.PutUint64(buf[8:16], h.PartitionStart)
+	binary.LittleEndian.PutUint64(buf[16:24], h.PartitionSize)
+	copy(buf[24:40], guidToMixedEndian(h.PartitionSignature))
+	buf[40] = gptMBRType
+	buf[41] = gptSignatureType
+
+	return buf, nil
+}
+
+// filePathElem represents UEFI File Path Media Device Path (Type 0x04, SubType 0x04).
+type filePathElem struct {
+	Path string // e.g., `\EFI\boot\BOOTX64.efi`
+}
+
+func (f *filePathElem) typ() uint8     { return dpTypeMedia }
+func (f *filePathElem) subType() uint8 { return dpSubTypeFilePath }
+
+func (f *filePathElem) data() ([]byte, error) {
+	// Convert forward slashes to backslashes
+	path := strings.ReplaceAll(f.Path, "/", "\\")
+
+	pathBytes, err := efiEncoding.NewEncoder().Bytes([]byte(path))
+	if err != nil {
+		return nil, errors.Wrap(err, "encoding file path to UTF-16LE")
+	}
+
+	pathBytes = append(pathBytes, 0x00, 0x00) // null terminator
+
+	totalLen := 4 + len(pathBytes)
+	buf := make([]byte, totalLen)
+	buf[0] = dpTypeMedia
+	buf[1] = dpSubTypeFilePath
+	binary.LittleEndian.PutUint16(buf[2:4], uint16(totalLen))
+	copy(buf[4:], pathBytes)
+
+	return buf, nil
+}
+
+// endOfDevicePath represents UEFI End of Device Path (Type 0x7F, SubType 0xFF).
+type endOfDevicePath struct{}
+
+func (e *endOfDevicePath) typ() uint8     { return dpTypeEnd }
+func (e *endOfDevicePath) subType() uint8 { return dpSubTypeEnd }
+
+func (e *endOfDevicePath) data() ([]byte, error) {
+	return []byte{dpTypeEnd, dpSubTypeEnd, 0x04, 0x00}, nil
+}
+
+// guidToMixedEndian converts a uuid.UUID (RFC 4122, big-endian time fields)
+// to UEFI mixed-endian format (little-endian for first 3 groups).
+func guidToMixedEndian(id uuid.UUID) []byte {
+	out := make([]byte, 16)
+	copy(out, id[:])
+	// Reverse bytes 0-3 (time_low)
+	out[0], out[1], out[2], out[3] = id[3], id[2], id[1], id[0]
+	// Reverse bytes 4-5 (time_mid)
+	out[4], out[5] = id[5], id[4]
+	// Reverse bytes 6-7 (time_hi_and_version)
+	out[6], out[7] = id[7], id[6]
+	// Bytes 8-15 stay as-is
+
+	return out
+}
+
+func setBootEntry(rw efiReadWriter, idx int, opt *loadOption) error {
+	data, err := opt.marshal()
+	if err != nil {
+		return errors.Wrap(err, "marshaling load option")
+	}
+
+	return rw.Write(scopeGlobal, fmt.Sprintf("Boot%04X", idx), attrNonVolatile|attrRuntimeAccess, data)
+}
+
+func findFreeBootIndex(rw efiReadWriter) (int, error) {
+	varNames, err := rw.List(scopeGlobal)
+	if err != nil {
+		return 0, errors.Wrap(err, "listing EFI variables")
+	}
+
+	usedIndices := make(map[int]bool)
+
+	for _, varName := range varNames {
+		s := bootVarRegexp.FindStringSubmatch(varName)
+		if s == nil {
+			continue
+		}
+
+		idx, err := strconv.ParseUint(s[1], 16, 16)
+		if err != nil {
+			continue
+		}
+
+		usedIndices[int(idx)] = true
+	}
+
+	for i := range 0x10000 {
+		if !usedIndices[i] {
+			return i, nil
+		}
+	}
+
+	return 0, errors.New("no free boot entry index available")
+}
+
+// espInfo contains information about the EFI System Partition on a disk.
+type espInfo struct {
+	PartitionNumber uint32
+	StartLBA        uint64
+	SizeLBA         uint64
+	PartitionGUID   uuid.UUID
+}
+
+func getESPInfo(diskPath string) (*espInfo, error) {
+	d, err := diskfs.Open(diskPath, diskfs.WithOpenMode(diskfs.ReadOnly))
+	if err != nil {
+		return nil, errors.Wrapf(err, "opening disk %s", diskPath)
+	}
+	defer d.Close()
+
+	table, err := d.GetPartitionTable()
+	if err != nil {
+		return nil, errors.Wrap(err, "reading partition table")
+	}
+
+	gptTable, ok := table.(*gpt.Table)
+	if !ok {
+		return nil, errors.New("disk does not have a GPT partition table")
+	}
+
+	for i, part := range gptTable.Partitions {
+		if part == nil {
+			continue
+		}
+
+		if part.Type != gpt.EFISystemPartition {
+			continue
+		}
+
+		partGUID, err := uuid.Parse(part.GUID)
+		if err != nil {
+			return nil, errors.Wrapf(err, "parsing partition GUID %q", part.GUID)
+		}
+
+		sectorSize := uint64(gptTable.LogicalSectorSize)
+		if sectorSize == 0 {
+			sectorSize = 512
+		}
+
+		return &espInfo{
+			PartitionNumber: uint32(i + 1),
+			StartLBA:        part.Start,
+			SizeLBA:         part.Size / sectorSize,
+			PartitionGUID:   partGUID,
+		}, nil
+	}
+
+	return nil, errors.Newf("EFI System Partition not found on %s", diskPath)
+}
+
+// sdbootFilePath returns the EFI file path for sd-boot based on architecture.
+func sdbootFilePath() (string, error) {
+	switch runtime.GOARCH {
+	case "amd64":
+		return `\EFI\boot\BOOTX64.efi`, nil
+	case "arm64":
+		return `\EFI\boot\BOOTAA64.efi`, nil
+	default:
+		return "", errors.Newf("unsupported architecture: %s", runtime.GOARCH)
+	}
 }

--- a/internal/efi/efi_test.go
+++ b/internal/efi/efi_test.go
@@ -5,6 +5,8 @@ package efi
 import (
 	"bytes"
 	"encoding/binary"
+	"io/fs"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -244,5 +246,350 @@ func TestScopeGlobalUUID(t *testing.T) {
 	expected := "8be4df61-93ca-11d2-aa0d-00e098032b8c"
 	if scopeGlobal.String() != expected {
 		t.Errorf("scopeGlobal = %q, want %q", scopeGlobal.String(), expected)
+	}
+}
+
+func TestGUIDToMixedEndian(t *testing.T) {
+	// UUID from Talos boot_test.go: 15e39a00-1dd2-1000-8d7f-00a0c92408fc
+	// Expected mixed-endian bytes (from the test hex dump):
+	// 00 9A E3 15 D2 1D 00 10 8D 7F 00 A0 C9 24 08 FC
+	id := uuid.MustParse("15e39a00-1dd2-1000-8d7f-00a0c92408fc")
+	got := guidToMixedEndian(id)
+	want := []byte{
+		0x00, 0x9A, 0xE3, 0x15, // time_low reversed
+		0xD2, 0x1D, // time_mid reversed
+		0x00, 0x10, // time_hi reversed
+		0x8D, 0x7F, 0x00, 0xA0, 0xC9, 0x24, 0x08, 0xFC, // as-is
+	}
+
+	if !bytes.Equal(got, want) {
+		t.Errorf("guidToMixedEndian() =\n  %X\nwant:\n  %X", got, want)
+	}
+}
+
+func TestEndOfDevicePathData(t *testing.T) {
+	e := &endOfDevicePath{}
+	got, err := e.data()
+	if err != nil {
+		t.Fatalf("data() error: %v", err)
+	}
+
+	want := []byte{0x7F, 0xFF, 0x04, 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("endOfDevicePath.data() = %X, want %X", got, want)
+	}
+}
+
+func TestHardDrivePathData(t *testing.T) {
+	// Values from Talos boot_test.go example
+	h := &hardDrivePath{
+		PartitionNumber:    1,
+		PartitionStart:     5,
+		PartitionSize:      8,
+		PartitionSignature: uuid.MustParse("15e39a00-1dd2-1000-8d7f-00a0c92408fc"),
+	}
+
+	got, err := h.data()
+	if err != nil {
+		t.Fatalf("data() error: %v", err)
+	}
+
+	if len(got) != hardDrivePathLen {
+		t.Fatalf("len = %d, want %d", len(got), hardDrivePathLen)
+	}
+
+	// Check header
+	if got[0] != 0x04 || got[1] != 0x01 {
+		t.Errorf("type/subtype = %02X/%02X, want 04/01", got[0], got[1])
+	}
+
+	if binary.LittleEndian.Uint16(got[2:4]) != hardDrivePathLen {
+		t.Errorf("length = %d, want %d", binary.LittleEndian.Uint16(got[2:4]), hardDrivePathLen)
+	}
+
+	// Check partition number
+	if binary.LittleEndian.Uint32(got[4:8]) != 1 {
+		t.Errorf("partition number = %d, want 1", binary.LittleEndian.Uint32(got[4:8]))
+	}
+
+	// Check start/size
+	if binary.LittleEndian.Uint64(got[8:16]) != 5 {
+		t.Errorf("start = %d, want 5", binary.LittleEndian.Uint64(got[8:16]))
+	}
+
+	if binary.LittleEndian.Uint64(got[16:24]) != 8 {
+		t.Errorf("size = %d, want 8", binary.LittleEndian.Uint64(got[16:24]))
+	}
+
+	// Check GUID in mixed-endian
+	wantGUID := []byte{0x00, 0x9A, 0xE3, 0x15, 0xD2, 0x1D, 0x00, 0x10, 0x8D, 0x7F, 0x00, 0xA0, 0xC9, 0x24, 0x08, 0xFC}
+	if !bytes.Equal(got[24:40], wantGUID) {
+		t.Errorf("GUID = %X, want %X", got[24:40], wantGUID)
+	}
+
+	// Check GPT signature type
+	if got[40] != 0x02 || got[41] != 0x02 {
+		t.Errorf("MBR/sig type = %02X/%02X, want 02/02", got[40], got[41])
+	}
+}
+
+func TestFilePathElemData(t *testing.T) {
+	f := &filePathElem{Path: `\EFI\boot\BOOTX64.efi`}
+	got, err := f.data()
+	if err != nil {
+		t.Fatalf("data() error: %v", err)
+	}
+
+	// Check header
+	if got[0] != 0x04 || got[1] != 0x04 {
+		t.Errorf("type/subtype = %02X/%02X, want 04/04", got[0], got[1])
+	}
+
+	totalLen := binary.LittleEndian.Uint16(got[2:4])
+	if int(totalLen) != len(got) {
+		t.Errorf("length field = %d, actual = %d", totalLen, len(got))
+	}
+
+	// Check that the path ends with null terminator (0x00 0x00)
+	if got[len(got)-1] != 0x00 || got[len(got)-2] != 0x00 {
+		t.Errorf("missing null terminator at end: %X", got[len(got)-2:])
+	}
+}
+
+func TestFilePathForwardSlashConversion(t *testing.T) {
+	f := &filePathElem{Path: `/EFI/boot/BOOTX64.efi`}
+	got, err := f.data()
+	if err != nil {
+		t.Fatalf("data() error: %v", err)
+	}
+
+	// Decode the path back and verify backslashes
+	pathBytes := got[4 : len(got)-2] // skip header and null terminator
+	decoded, err := efiEncoding.NewDecoder().Bytes(pathBytes)
+	if err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if string(decoded) != `\EFI\boot\BOOTX64.efi` {
+		t.Errorf("decoded path = %q, want %q", string(decoded), `\EFI\boot\BOOTX64.efi`)
+	}
+}
+
+func TestLoadOptionMarshal(t *testing.T) {
+	opt := &loadOption{
+		Description: "Test",
+		FilePath: devicePath{
+			&hardDrivePath{
+				PartitionNumber:    1,
+				PartitionStart:     2048,
+				PartitionSize:      614400,
+				PartitionSignature: uuid.MustParse("fa7141e7-c13a-4788-acd6-8a841eeca4e1"),
+			},
+			&filePathElem{Path: `\EFI\boot\BOOTX64.efi`},
+			&endOfDevicePath{},
+		},
+	}
+
+	data, err := opt.marshal()
+	if err != nil {
+		t.Fatalf("marshal() error: %v", err)
+	}
+
+	// Verify attributes (LOAD_OPTION_ACTIVE = 0x01)
+	attrs := binary.LittleEndian.Uint32(data[0:4])
+	if attrs != 0x01 {
+		t.Errorf("attributes = 0x%08X, want 0x00000001", attrs)
+	}
+
+	// Verify FilePathListLength at bytes 4-5
+	fpLen := binary.LittleEndian.Uint16(data[4:6])
+	if fpLen == 0 {
+		t.Error("FilePathListLength = 0, expected non-zero")
+	}
+
+	// Round-trip: unmarshal should recover the description
+	unmarshaled, err := unmarshalLoadOption(data)
+	if err != nil {
+		t.Fatalf("unmarshalLoadOption() error: %v", err)
+	}
+
+	if unmarshaled.Description != "Test" {
+		t.Errorf("round-trip description = %q, want %q", unmarshaled.Description, "Test")
+	}
+}
+
+// mockEFIReadWriter is an in-memory efiReadWriter for testing.
+type mockEFIReadWriter struct {
+	vars map[string]mockVar
+}
+
+type mockVar struct {
+	data  []byte
+	attrs efiAttribute
+}
+
+func newMockEFIReadWriter() *mockEFIReadWriter {
+	return &mockEFIReadWriter{vars: make(map[string]mockVar)}
+}
+
+func (m *mockEFIReadWriter) Write(scope uuid.UUID, varName string, attrs efiAttribute, value []byte) error {
+	key := varName + "-" + scope.String()
+	m.vars[key] = mockVar{data: append([]byte(nil), value...), attrs: attrs}
+
+	return nil
+}
+
+func (m *mockEFIReadWriter) Read(scope uuid.UUID, varName string) ([]byte, efiAttribute, error) {
+	key := varName + "-" + scope.String()
+	v, ok := m.vars[key]
+	if !ok {
+		return nil, 0, &fakeNotExistError{name: key}
+	}
+
+	return v.data, v.attrs, nil
+}
+
+func (m *mockEFIReadWriter) Delete(scope uuid.UUID, varName string) error {
+	key := varName + "-" + scope.String()
+	delete(m.vars, key)
+
+	return nil
+}
+
+func (m *mockEFIReadWriter) List(scope uuid.UUID) ([]string, error) {
+	suffix := "-" + scope.String()
+	var names []string
+
+	for key := range m.vars {
+		if name, ok := strings.CutSuffix(key, suffix); ok {
+			names = append(names, name)
+		}
+	}
+
+	return names, nil
+}
+
+type fakeNotExistError struct{ name string }
+
+func (e *fakeNotExistError) Error() string { return "not found: " + e.name }
+func (e *fakeNotExistError) Is(target error) bool {
+	return target == fs.ErrNotExist //nolint:errorlint // intentional sentinel comparison
+}
+
+func TestFindFreeBootIndex(t *testing.T) {
+	mock := newMockEFIReadWriter()
+
+	// Write some existing entries
+	_ = mock.Write(scopeGlobal, "Boot0000", 0, []byte("x"))
+	_ = mock.Write(scopeGlobal, "Boot0001", 0, []byte("x"))
+	_ = mock.Write(scopeGlobal, "Boot0003", 0, []byte("x"))
+
+	idx, err := findFreeBootIndex(mock)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if idx != 2 {
+		t.Errorf("findFreeBootIndex() = %d, want 2", idx)
+	}
+}
+
+func TestFindFreeBootIndexEmpty(t *testing.T) {
+	mock := newMockEFIReadWriter()
+
+	idx, err := findFreeBootIndex(mock)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+
+	if idx != 0 {
+		t.Errorf("findFreeBootIndex() = %d, want 0", idx)
+	}
+}
+
+func TestSetBootEntry(t *testing.T) {
+	mock := newMockEFIReadWriter()
+
+	opt := &loadOption{
+		Description: talosBootEntryDescription,
+		FilePath: devicePath{
+			&endOfDevicePath{},
+		},
+	}
+
+	err := setBootEntry(mock, 5, opt)
+	if err != nil {
+		t.Fatalf("setBootEntry() error: %v", err)
+	}
+
+	// Verify the variable was written
+	key := "Boot0005-" + scopeGlobal.String()
+	v, ok := mock.vars[key]
+	if !ok {
+		t.Fatal("Boot0005 was not written")
+	}
+
+	// Unmarshal and check description
+	parsed, err := unmarshalLoadOption(v.data)
+	if err != nil {
+		t.Fatalf("unmarshalLoadOption() error: %v", err)
+	}
+
+	if parsed.Description != talosBootEntryDescription {
+		t.Errorf("description = %q, want %q", parsed.Description, talosBootEntryDescription)
+	}
+}
+
+// TestLoadOptionMarshalMatchesTalosFormat verifies our marshaling against the
+// known hex dump from Talos boot_test.go.
+func TestLoadOptionMarshalMatchesTalosFormat(t *testing.T) {
+	opt := &loadOption{
+		Description: "Example",
+		FilePath: devicePath{
+			&hardDrivePath{
+				PartitionNumber:    1,
+				PartitionStart:     5,
+				PartitionSize:      8,
+				PartitionSignature: uuid.MustParse("15e39a00-1dd2-1000-8d7f-00a0c92408fc"),
+			},
+			&filePathElem{Path: `\test\a.efi`},
+			&endOfDevicePath{},
+		},
+	}
+
+	data, err := opt.marshal()
+	if err != nil {
+		t.Fatalf("marshal() error: %v", err)
+	}
+
+	// Known expected bytes from Talos boot_test.go
+	expected := []byte{
+		// Attributes: LOAD_OPTION_ACTIVE
+		0x01, 0x00, 0x00, 0x00,
+		// FilePathListLength
+		0x4A, 0x00,
+		// Description "Example" in UTF-16LE + null
+		0x45, 0x00, 0x78, 0x00, 0x61, 0x00, 0x6D, 0x00,
+		0x70, 0x00, 0x6C, 0x00, 0x65, 0x00,
+		0x00, 0x00,
+		// HardDrivePath
+		0x04, 0x01, 0x2A, 0x00,
+		0x01, 0x00, 0x00, 0x00,
+		0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x9A, 0xE3, 0x15, 0xD2, 0x1D, 0x00, 0x10,
+		0x8D, 0x7F, 0x00, 0xA0, 0xC9, 0x24, 0x08, 0xFC,
+		0x02, 0x02,
+		// FilePath "\test\a.efi"
+		0x04, 0x04, 0x1C, 0x00,
+		0x5C, 0x00, 0x74, 0x00, 0x65, 0x00, 0x73, 0x00,
+		0x74, 0x00, 0x5C, 0x00, 0x61, 0x00, 0x2E, 0x00,
+		0x65, 0x00, 0x66, 0x00, 0x69, 0x00, 0x00, 0x00,
+		// End of Device Path
+		0x7F, 0xFF, 0x04, 0x00,
+	}
+
+	if !bytes.Equal(data, expected) {
+		t.Errorf("marshal() output does not match Talos format\ngot:\n  %X\nwant:\n  %X", data, expected)
 	}
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -268,29 +268,16 @@ cluster:
 	}
 	log.Print("Talos installer finished successfully")
 
-	// Get UKI file name and partition info from installed image (loop device) before copying
-	// We need this info to update EFI variables after copying
-	var ukiPath string
-	var rawBlkidInfo any
-	if efi.IsUEFIBoot() {
-		var err error
-		ukiPath, rawBlkidInfo, err = efi.GetUKIAndPartitionInfo(loop, raw)
-		if err != nil {
-			log.Printf("warning: failed to get UKI and partition info: %v", err)
-		}
-	}
-
 	log.Print("remounting all filesystems read-only")
 	_ = os.WriteFile("/proc/sysrq-trigger", []byte("u"), 0)
 
 	CopyWithFsync(raw, disk)
 	log.Printf("installation image copied to %s", disk)
 
-	// Update EFI variables AFTER copying image
-	// Update BootOrder to put Talos boot entry first (created by installer)
-	if efi.IsUEFIBoot() && ukiPath != "" {
-		log.Print("updating EFI variables")
-		if err := efi.UpdateEFIVariables(disk, ukiPath, rawBlkidInfo); err != nil {
+	// Create EFI boot entry pointing to the target disk's ESP
+	if efi.IsUEFIBoot() {
+		log.Print("creating EFI boot entry")
+		if err := efi.UpdateEFIVariables(disk); err != nil {
 			log.Printf("warning: failed to update EFI variables: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary

- Create a proper UEFI boot entry with HD() device path pointing to the real target disk's ESP, instead of relying on the Talos installer which skips EFI variable creation on loop devices
- Read GPT partition table from the target disk after image copy to obtain the correct ESP partition UUID, start LBA, and size
- Serialization format verified against Talos upstream boot_test.go hex dumps

## Test plan

- [x] Binary tested on real hardware (Dell server with UEFI)
- [x] Unit tests for UEFI Load Option marshaling (matches Talos format byte-for-byte)
- [x] Unit tests for device path serialization (HardDrivePath, FilePath, EndOfDevicePath)
- [x] Unit tests for mixed-endian GUID conversion
- [x] Builds for linux/amd64 and linux/arm64
- [x] Linter passes with 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified EFI boot entry creation process during installation. The system now directly constructs and writes boot entries to the target disk's EFI System Partition, eliminating the need for pre-copy queries.

* **Tests**
  * Added comprehensive unit tests for EFI data marshaling and boot entry operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->