### PR TITLE
feat: update default Talos image to v1.12.6

### DIFF
--- a/cmd/boot-to-talos/main.go
+++ b/cmd/boot-to-talos/main.go
@@ -26,7 +26,7 @@ var (
 
 func init() {
 	flag.StringVar(&imageFlag, "image",
-		"ghcr.io/cozystack/cozystack/talos:v1.11.6", "Talos installer image")
+		"ghcr.io/cozystack/cozystack/talos:v1.12.6", "Talos installer image")
 	flag.StringVar(&diskFlag, "disk", "", "target disk (will be wiped)")
 	flag.BoolVar(&cli.YesFlag, "yes", false, "automatic yes to prompts")
 	flag.StringVar(&modeFlag, "mode", "", "mode: boot or install")


### PR DESCRIPTION
## Summary
- Update default Talos installer image from v1.11.6 to v1.12.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default Talos installer image version from v1.11.6 to v1.12.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->