### PR TITLE
fix(network): fall back to ethtool ioctl when sysfs perm_addr is missing

### DIFF
--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -632,10 +632,15 @@ func isZeroMAC(mac net.HardwareAddr) bool {
 }
 
 // ethtoolIfreq mirrors struct ifreq with the ifr_data union pointer used by
-// SIOCETHTOOL. The Name field is null-terminated and bounded by IFNAMSIZ.
+// SIOCETHTOOL. The trailing pad field is critical: the kernel copies
+// sizeof(struct ifreq) bytes out of userspace on SIOCETHTOOL, so the Go-side
+// layout must match the full kernel struct size or the syscall reads past the
+// end of the allocation. The pad width is derived from unix.Ifreq so it stays
+// correct on every architecture.
 type ethtoolIfreq struct {
 	Name [unix.IFNAMSIZ]byte
 	Data unsafe.Pointer
+	_    [unsafe.Sizeof(unix.Ifreq{}) - unix.IFNAMSIZ - unsafe.Sizeof(unsafe.Pointer(nil))]byte
 }
 
 // ethtoolPermAddrCmd mirrors struct ethtool_perm_addr from <linux/ethtool.h>.

--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"unsafe"
 
 	"github.com/cockroachdb/errors"
 	"github.com/jsimonetti/rtnetlink/v2"
@@ -586,17 +587,100 @@ func IfaceAddr(name string) (ip, mask string, err error) {
 }
 
 // getPermanentMAC returns the permanent (hardware) MAC address of the interface.
-// This reads from /sys/class/net/<iface>/perm_addr which contains the original
-// hardware MAC address that doesn't change even if user modifies the active MAC.
+//
+// Primary source is /sys/class/net/<iface>/perm_addr, which contains the original
+// hardware MAC that does not change when the active MAC is rewritten (most
+// notably by Linux bonding, which replaces slave MACs with the master MAC).
+//
+// Some drivers/kernels do not expose perm_addr in sysfs, or expose it as the
+// all-zero address. In both cases we fall back to the ethtool ETHTOOL_GPERMADDR
+// ioctl, which is the canonical netlink-independent way to obtain the burned-in
+// hardware address. Without this fallback, every slave of an active bond is
+// reported with the bond master's MAC, which collapses the predictable
+// enx<mac> name space and breaks the kernel bond= cmdline (both slaves end up
+// with identical names).
 func getPermanentMAC(name string) (net.HardwareAddr, error) {
+	if mac, err := readSysfsPermAddr(name); err == nil && !isZeroMAC(mac) {
+		return mac, nil
+	}
+
+	return ethtoolPermAddr(name)
+}
+
+// readSysfsPermAddr reads /sys/class/net/<name>/perm_addr. Returns the parsed
+// MAC, which may be the all-zero address when the driver does not populate it.
+func readSysfsPermAddr(name string) (net.HardwareAddr, error) {
 	path := fmt.Sprintf("/sys/class/net/%s/perm_addr", name)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
+	return net.ParseMAC(strings.TrimSpace(string(data)))
+}
 
-	macStr := strings.TrimSpace(string(data))
-	return net.ParseMAC(macStr)
+// isZeroMAC reports whether the address is empty or all zero bytes.
+func isZeroMAC(mac net.HardwareAddr) bool {
+	if len(mac) == 0 {
+		return true
+	}
+	for _, b := range mac {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// ethtoolIfreq mirrors struct ifreq with the ifr_data union pointer used by
+// SIOCETHTOOL. The Name field is null-terminated and bounded by IFNAMSIZ.
+type ethtoolIfreq struct {
+	Name [unix.IFNAMSIZ]byte
+	Data unsafe.Pointer
+}
+
+// ethtoolPermAddrCmd mirrors struct ethtool_perm_addr from <linux/ethtool.h>.
+// MaxAddrLen (32) is the kernel-side MAX_ADDR_LEN upper bound; for Ethernet
+// interfaces Size comes back as 6.
+type ethtoolPermAddrCmd struct {
+	Cmd  uint32
+	Size uint32
+	Data [32]byte
+}
+
+// ethtoolPermAddr issues ETHTOOL_GPERMADDR via SIOCETHTOOL to fetch the
+// burned-in hardware address of the interface, bypassing any active MAC
+// override (e.g. one imposed by bonding).
+func ethtoolPermAddr(name string) (net.HardwareAddr, error) {
+	if len(name) >= unix.IFNAMSIZ {
+		return nil, errors.Newf("interface name %q exceeds IFNAMSIZ", name)
+	}
+
+	fd, err := unix.Socket(unix.AF_INET, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "ethtool: open socket")
+	}
+	defer unix.Close(fd)
+
+	cmd := ethtoolPermAddrCmd{
+		Cmd:  unix.ETHTOOL_GPERMADDR,
+		Size: uint32(len(ethtoolPermAddrCmd{}.Data)),
+	}
+	ifr := ethtoolIfreq{Data: unsafe.Pointer(&cmd)}
+	copy(ifr.Name[:], name)
+
+	if _, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), unix.SIOCETHTOOL, uintptr(unsafe.Pointer(&ifr))); errno != 0 {
+		return nil, errors.Wrapf(errno, "ethtool: SIOCETHTOOL ETHTOOL_GPERMADDR on %s", name)
+	}
+
+	if cmd.Size == 0 || cmd.Size > uint32(len(cmd.Data)) {
+		return nil, errors.Newf("ethtool: implausible permanent address size %d on %s", cmd.Size, name)
+	}
+	mac := make(net.HardwareAddr, cmd.Size)
+	copy(mac, cmd.Data[:cmd.Size])
+	if isZeroMAC(mac) {
+		return nil, errors.Newf("ethtool: permanent address on %s is all zero", name)
+	}
+	return mac, nil
 }
 
 // macToInterfaceName converts a MAC address to a predictable interface name.

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"net"
 	"strings"
 	"testing"
 
@@ -13,6 +14,28 @@ import (
 
 	"github.com/cozystack/boot-to-talos/internal/cli"
 )
+
+func TestIsZeroMAC(t *testing.T) {
+	tests := []struct {
+		name string
+		mac  net.HardwareAddr
+		want bool
+	}{
+		{"nil", nil, true},
+		{"empty", net.HardwareAddr{}, true},
+		{"all zero", net.HardwareAddr{0, 0, 0, 0, 0, 0}, true},
+		{"first byte set", net.HardwareAddr{0x10, 0, 0, 0, 0, 0}, false},
+		{"last byte set", net.HardwareAddr{0, 0, 0, 0, 0, 0x01}, false},
+		{"non-zero throughout", net.HardwareAddr{0x10, 0xff, 0xe0, 0x3a, 0xd6, 0x86}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isZeroMAC(tc.mac); got != tc.want {
+				t.Errorf("isZeroMAC(%v) = %v, want %v", tc.mac, got, tc.want)
+			}
+		})
+	}
+}
 
 func TestPickInterface(t *testing.T) {
 	tests := []struct {

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -9,11 +9,26 @@ import (
 	"net"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/cockroachdb/errors"
+	"golang.org/x/sys/unix"
 
 	"github.com/cozystack/boot-to-talos/internal/cli"
 )
+
+// TestEthtoolIfreqSizeMatchesKernel guards against the OOB-read class of bugs
+// where Go's ethtoolIfreq is smaller than the kernel's struct ifreq. The
+// SIOCETHTOOL ioctl path copies sizeof(struct ifreq) bytes out of userspace,
+// so any future field rearrangement that shrinks ethtoolIfreq below
+// unix.Ifreq's size would let the kernel read past the allocation boundary.
+func TestEthtoolIfreqSizeMatchesKernel(t *testing.T) {
+	got := unsafe.Sizeof(ethtoolIfreq{})
+	want := unsafe.Sizeof(unix.Ifreq{})
+	if got != want {
+		t.Errorf("ethtoolIfreq size = %d, want %d (struct ifreq size); SIOCETHTOOL would read out of bounds", got, want)
+	}
+}
 
 func TestIsZeroMAC(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

`getPermanentMAC` reads `/sys/class/net/<if>/perm_addr` only. On some
driver/kernel combinations that file does not exist, or contains the
all-zero address. The current fallback returns the active MAC, but for a
bond slave the active MAC has already been rewritten to the bond master's
MAC. The result is that both slaves of an LACP bond resolve to the same
`enx<mac>` predictable name, and `GenerateBondCmdline` emits something like:

    bond=bond0:enxd283bcf788ae,enxd283bcf788ae:mode=802.3ad,...

After kexec into Talos, the bond cannot be assembled from a single
duplicated slave name, the VLAN never comes up, and the host loses network.

## Fix

Add an `ETHTOOL_GPERMADDR` ioctl fallback to `getPermanentMAC`. The ethtool
interface returns the burned-in hardware address directly from the driver
and is unaffected by bonding's MAC rewrite. The sysfs path remains the
primary source; ethtool is consulted only when sysfs is missing or returns
all zeros.

For non-Ethernet master devices (bond, VLAN, bridge) ethtool also returns
all zeros, which is caught and propagated as an error so the existing
`net.InterfaceByName` fallback in `PrettyName` keeps its current behaviour.

## Validation

- New `TestIsZeroMAC` covers the zero-detection helper.
- Existing `internal/network` tests pass on linux/amd64.
- Verified on an affected host (kernel 6.8, Intel igb, 802.3ad bond):
  before the fix, sysfs `perm_addr` is absent and both slaves report the
  bond master MAC via sysfs `address`; after the fix, the ioctl returns
  the correct per-slave permanent MACs and the generated cmdline lists two
  distinct `enx<mac>` names. End-to-end kexec into Talos confirmed the
  bond/VLAN/IP stack comes up correctly.

## Notes

- No new dependencies; uses `golang.org/x/sys/unix` already present.
- Linux-only file, matches the existing `//go:build linux` constraint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permanent MAC address detection by adding a more reliable lookup flow with stronger validation, ensuring the correct burned-in hardware address is used when available.

* **Tests**
  * Added unit test coverage for MAC address “zero/invalid” detection to better confirm correct handling of edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->