### PR TITLE
fix(network): only rewrite MAC-based interface names to enx<mac>

### DIFF
--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -697,24 +697,34 @@ func macToInterfaceName(mac net.HardwareAddr) string {
 	return "enx" + strings.ToLower(macHex)
 }
 
-// PrettyName returns the predictable network interface name based on permanent MAC address.
-// Format: enx<mac> where mac is the permanent hardware MAC address without colons.
-// This ensures the interface name remains consistent across reboots even if
-// the user has modified the active MAC address.
+// PrettyName returns the interface name that Talos will assign to the link,
+// so it can be referenced verbatim in the ip=/vlan=/bond= kernel cmdline.
+//
+// systemd/udev derives predictable names from the same net_id logic in the
+// source OS and in Talos, with a fixed priority: firmware onboard index
+// (eno1) > PCI hotplug slot (ens1) > geographical PCI path (enp2s0f0) > MAC
+// address (enx<mac>). Only the last scheme encodes the MAC into the name, so
+// only it is unstable when the active MAC is rewritten (most notably a bond
+// slave inheriting the master's MAC, which collapses every slave onto one
+// name). For every other scheme the live name is already the stable,
+// Talos-visible primary name and must pass through unchanged: rewriting eno1
+// into enx<mac> yields a name Talos never assigns as primary, so the kernel's
+// early ip=/vlan= link lookup fails and the interface never comes up.
+//
+// Therefore only mac-based names are recomputed from the permanent hardware
+// MAC (via perm_addr / ethtool), which restores distinct, stable names for
+// bond slaves whose active MAC was overwritten. All other names are returned
+// as-is.
 func PrettyName(name string) string {
-	// Try to get permanent MAC address first
-	mac, err := getPermanentMAC(name)
-	if err == nil && len(mac) > 0 {
-		return macToInterfaceName(mac)
-	}
-
-	// Fallback: try to get current MAC from interface
-	ifc, err := net.InterfaceByName(name)
-	if err != nil {
+	if !strings.HasPrefix(name, "enx") {
 		return name
 	}
-	if len(ifc.HardwareAddr) > 0 {
-		return macToInterfaceName(ifc.HardwareAddr)
+
+	// Name is MAC-based: recompute from the permanent hardware MAC so a
+	// rewritten active MAC (e.g. a bond slave) does not collapse distinct
+	// slaves onto the master's MAC.
+	if mac, err := permanentMACFn(name); err == nil && len(mac) > 0 {
+		return macToInterfaceName(mac)
 	}
 
 	return name
@@ -752,6 +762,7 @@ var (
 	defaultRouteFn       = DefaultRoute
 	ifaceAddrFn          = IfaceAddr
 	prettyNameFn         = PrettyName
+	permanentMACFn       = getPermanentMAC
 	collectNetworkInfoFn = CollectNetworkInfo
 	fatalf               = log.Fatalf
 )

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -52,6 +52,59 @@ func TestIsZeroMAC(t *testing.T) {
 	}
 }
 
+// swapPermMAC swaps the injected permanent-MAC lookup for the duration of the
+// test, restoring the original via t.Cleanup. PrettyName consults it only for
+// mac-based (enx*) names, so tests can assert the recompute path without a
+// real NIC.
+func swapPermMAC(t *testing.T, fn func(string) (net.HardwareAddr, error)) {
+	t.Helper()
+	orig := permanentMACFn
+	permanentMACFn = fn
+	t.Cleanup(func() { permanentMACFn = orig })
+}
+
+// TestPrettyName pins the core invariant behind the onboard-interface fix:
+// only mac-based (enx*) names are recomputed from the permanent hardware MAC;
+// every other predictable name (onboard eno1, slot ens1, path enp2s0f0, and
+// VLAN children thereof) must reach the kernel cmdline verbatim, because that
+// is the exact name Talos assigns as primary. Rewriting eno1 into enx<mac>
+// was the regression that left the interface without networking.
+func TestPrettyName(t *testing.T) {
+	// Poison the permanent-MAC lookup: PrettyName must NOT consult it for
+	// non-mac-based names. If it does, the returned name changes and the
+	// assertions below fail loudly.
+	poison := func(string) (net.HardwareAddr, error) {
+		return net.HardwareAddr{0xde, 0xad, 0xbe, 0xef, 0x00, 0x01}, nil
+	}
+
+	t.Run("onboard/slot/path names pass through verbatim", func(t *testing.T) {
+		swapPermMAC(t, poison)
+		for _, name := range []string{"eno1", "ens1", "enp2s0f0", "eth0", "bond0", "eno1.321"} {
+			if got := PrettyName(name); got != name {
+				t.Errorf("PrettyName(%q) = %q, want %q (must not be rewritten)", name, got, name)
+			}
+		}
+	})
+
+	t.Run("mac-based name recomputed from permanent MAC", func(t *testing.T) {
+		swapPermMAC(t, func(string) (net.HardwareAddr, error) {
+			return net.HardwareAddr{0x20, 0x67, 0x7c, 0xd4, 0xce, 0xd4}, nil
+		})
+		if got, want := PrettyName("enxaabbccddeeff"), "enx20677cd4ced4"; got != want {
+			t.Errorf("PrettyName(enx...) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("mac-based name falls back to input when perm MAC unavailable", func(t *testing.T) {
+		swapPermMAC(t, func(string) (net.HardwareAddr, error) {
+			return nil, errors.New("no perm addr")
+		})
+		if got, want := PrettyName("enx20677cd4ced4"), "enx20677cd4ced4"; got != want {
+			t.Errorf("PrettyName fallback = %q, want %q", got, want)
+		}
+	})
+}
+
 func TestPickInterface(t *testing.T) {
 	tests := []struct {
 		name             string


### PR DESCRIPTION
## Problem

`boot-to-talos` generated `ip=`/`vlan=` kernel cmdline args that referenced interface names like `enx20677cd4ced4`. On hardware where the NIC has a firmware onboard index (the port is named `eno1`), Talos never brought the interface up after `kexec`: networking stayed down and the node was unreachable.

## Root cause

`PrettyName` unconditionally rewrote every interface name to `enx<permanent-mac>`. But systemd/udev derive predictable names from the same `net_id` logic in the source OS and in Talos, with a fixed priority:

```
onboard (eno1) > slot (ens1) > path (enp2s0f0) > mac (enx<mac>)
```

MAC-based naming is the lowest priority. For an onboard/slot/path NIC the primary name is `eno1` / `ens1` / `enp2s0f0`, and `enx<mac>` is only an alternative name. Talos matches the primary name during its early `ip=`/`vlan=` link setup, so an `enx<mac>` reference does not resolve and the interface never comes up.

The runtime name in the source OS is already the stable, Talos-visible primary name (identical `net_id` logic), so it must be passed through verbatim.

## Fix

`PrettyName` now recomputes the name from the permanent hardware MAC **only when the runtime name is itself MAC-based** (`enx*`). This preserves the bond-slave name stability the `perm_addr` lookup was introduced for (a slave whose active MAC was overwritten by the bond master), while onboard/slot/path names reach the cmdline unchanged.

## Testing

- Added `TestPrettyName`: onboard/slot/path names (`eno1`, `ens1`, `enp2s0f0`, VLAN children) pass through verbatim; `enx*` names are recomputed from the injected permanent MAC; fallback to the input name when the permanent MAC is unavailable.
- Existing tests are unaffected (they inject `prettyNameFn`).
- Built for `linux/amd64` and verified on real hardware with an onboard NIC (`eno1`) carrying a tagged VLAN: the generated args changed from `vlan=enx…:enx… ip=…:enx….321:…` to `vlan=eno1.321:eno1 ip=…:eno1.321:none`.
