### PR TITLE
feat(network): configure additional VLANs on the same parent interface

### DIFF
--- a/internal/network/network.go
+++ b/internal/network/network.go
@@ -811,6 +811,62 @@ func vlanParentName(parent, actualDevice *LinkInfo, bondName string, fromOverrid
 	return prettyNameFn(parent.Name)
 }
 
+// additionalVLANArgs builds vlan=/ip= cmdline args for every VLAN stacked on
+// the same device (actualDevice) as the already-configured default-route VLAN
+// that carries its own IPv4 address — e.g. a private VLAN with no default
+// route. Each extra VLAN gets NO gateway: only the default-route VLAN carries
+// one, a second default gateway on the kernel cmdline would be wrong. The
+// operator confirms each one (auto-accepted under -yes). processedVLANs is the
+// default-route VLAN chain, which must not be emitted again.
+func additionalVLANArgs(info *NetworkInfo, processedVLANs []*LinkInfo, actualDevice *LinkInfo, bondName, hostname string, fromOverride bool) []string {
+	seen := make(map[uint32]bool, len(processedVLANs))
+	for _, v := range processedVLANs {
+		seen[v.Index] = true
+	}
+
+	var out []string
+	for i := range info.Links {
+		cand := &info.Links[i]
+		if !cand.IsVLAN() || cand.VLAN == nil || seen[cand.Index] {
+			continue
+		}
+		// Only VLANs stacked on the same device we just configured.
+		if ResolveNetworkDevice(info, cand) != actualDevice {
+			continue
+		}
+		caddr, cmask, err := ifaceAddrFn(cand.Name)
+		if err != nil {
+			continue // no IPv4 to carry — nothing to configure
+		}
+		parentName := vlanParentName(info.GetLinkByIndex(cand.LinkIndex), actualDevice, bondName, fromOverride)
+		if !cli.AskYesNo(fmt.Sprintf("Add VLAN %d (%s)?", cand.VLAN.VID, caddr), true) {
+			continue
+		}
+		cdev := cli.Ask("Network device for IP", fmt.Sprintf("%s.%d", parentName, cand.VLAN.VID))
+		caddr = cli.Ask("IP address", caddr)
+		cmask = cli.Ask("Netmask", cmask)
+		out = append(out,
+			fmt.Sprintf("vlan=%s:%s", cdev, parentName),
+			GenerateIPCmdline(caddr, "", cmask, hostname, cdev),
+		)
+	}
+	return out
+}
+
+// consoleArg prompts for a serial console and returns the console= kernel
+// argument, or "" when the operator opts out with "no"/"none". Shared by the
+// netlink and simple collection paths.
+func consoleArg() string {
+	console := cli.Ask("Configure serial console? (or 'no')", "ttyS0")
+	if console == "" {
+		console = "ttyS0"
+	}
+	if strings.EqualFold(console, "no") || strings.EqualFold(console, "none") {
+		return ""
+	}
+	return "console=" + console
+}
+
 //nolint:gocognit,forbidigo,funlen
 func collectKernelArgsNetlink(overrideIface string) []string {
 	// Try to collect network info via netlink
@@ -999,13 +1055,13 @@ func collectKernelArgsNetlink(overrideIface string) []string {
 	ipCmdline := GenerateIPCmdline(ip, gw, mask, hostname, ipDevice)
 	out = append(out, ipCmdline)
 
+	// Additional VLANs on the same device that carry their own IPv4 address
+	// (e.g. a private VLAN with no default route) are appended with no gateway.
+	out = append(out, additionalVLANArgs(netInfo, vlans, actualDevice, bondName, hostname, fromOverride)...)
+
 	// Serial console
-	console := cli.Ask("Configure serial console? (or 'no')", "ttyS0")
-	if console == "" {
-		console = "ttyS0"
-	}
-	if !strings.EqualFold(console, "no") && !strings.EqualFold(console, "none") {
-		out = append(out, "console="+console)
+	if c := consoleArg(); c != "" {
+		out = append(out, c)
 	}
 
 	return out
@@ -1057,12 +1113,8 @@ func collectKernelArgsSimple(overrideIface string) []string {
 		out = append(out, fmt.Sprintf("ip=%s::%s:%s:%s:%s:none", ip, gw, mask, hostname, dev))
 	}
 
-	console := cli.Ask("Configure serial console? (or 'no')", "ttyS0")
-	if console == "" {
-		console = "ttyS0"
-	}
-	if !strings.EqualFold(console, "no") && !strings.EqualFold(console, "none") {
-		out = append(out, "console="+console)
+	if c := consoleArg(); c != "" {
+		out = append(out, c)
 	}
 	return out
 }

--- a/internal/network/network_test.go
+++ b/internal/network/network_test.go
@@ -449,6 +449,63 @@ func TestCollectKernelArgsNetlink_OverrideRenamedVLANUsesUserName(t *testing.T) 
 	}
 }
 
+// TestCollectKernelArgsNetlink_MultiVLANSameParent proves that a second VLAN
+// on the same physical parent (a private VLAN with no default route) is picked
+// up in addition to the default-route VLAN: both get vlan=/ip= lines, and only
+// the default-route VLAN carries the gateway (a second default gateway on the
+// cmdline would be wrong).
+func TestCollectKernelArgsNetlink_MultiVLANSameParent(t *testing.T) {
+	withYes(t)
+	eno1 := LinkInfo{Name: "eno1", Index: 1, Kind: ""}
+	vlan321 := LinkInfo{Name: "vlan321", Index: 2, LinkIndex: 1, Kind: "vlan", VLAN: &VLANSpec{VID: 321, Protocol: 0x8100}}
+	vlan403 := LinkInfo{Name: "vlan403", Index: 3, LinkIndex: 1, Kind: "vlan", VLAN: &VLANSpec{VID: 403, Protocol: 0x8100}}
+	swapNetInfo(t, func() (*NetworkInfo, error) {
+		return buildNetInfo([]LinkInfo{eno1, vlan321, vlan403}), nil
+	})
+	swapFns(t,
+		// Default route via the public VLAN.
+		func() (string, string, error) { return "vlan321", "185.100.85.1", nil },
+		func(dev string) (string, string, error) {
+			switch dev {
+			case "vlan321":
+				return "185.100.85.71", "255.255.255.0", nil
+			case "vlan403":
+				return "10.100.85.71", "255.255.255.0", nil
+			}
+			return "", "", errors.New("no IPv4")
+		},
+		// Identity: keep eno1 as eno1 so the assertions read naturally.
+		func(s string) string { return s },
+	)
+
+	out := collectKernelArgsNetlink("")
+	if out == nil {
+		t.Fatal("expected cmdline, got nil")
+	}
+	joined := strings.Join(out, " ")
+
+	// Public VLAN: vlan= + ip= WITH the gateway.
+	if !strings.Contains(joined, "vlan=eno1.321:eno1") {
+		t.Errorf("missing public vlan= line: %q", joined)
+	}
+	if !strings.Contains(joined, "ip=185.100.85.71::185.100.85.1:") || !strings.Contains(joined, ":eno1.321:none") {
+		t.Errorf("public ip= line wrong or missing gateway: %q", joined)
+	}
+	// Private VLAN: vlan= + ip= WITHOUT a gateway (empty gw field).
+	if !strings.Contains(joined, "vlan=eno1.403:eno1") {
+		t.Errorf("missing private vlan= line: %q", joined)
+	}
+	if !strings.Contains(joined, "ip=10.100.85.71:::255.255.255.0:") || !strings.Contains(joined, ":eno1.403:none") {
+		t.Errorf("private ip= line wrong or should have empty gateway: %q", joined)
+	}
+	// The private VLAN must not carry the default gateway.
+	for _, a := range out {
+		if strings.Contains(a, "eno1.403") && strings.Contains(a, "185.100.85.1") {
+			t.Errorf("private VLAN must not carry default gateway: %q", a)
+		}
+	}
+}
+
 // TestCollectKernelArgsNetlink_OverrideBondSlaveNamesAreVerbatim pins the
 // bond= line slave-naming invariant on the override path: slaves go through
 // the injected prettyNameFn under no-override, but stay raw under override so


### PR DESCRIPTION
## Problem

`boot-to-talos` only configured the single interface that owns the default
route and resolved that one VLAN chain. On a NIC that carries more than one
tagged VLAN (e.g. a public VLAN with the default route plus a private VLAN
without one), only the default-route VLAN reached the kernel cmdline. The
other VLANs were dropped and never came up under Talos.

## Change

After configuring the default-route VLAN, detect every other VLAN stacked on
the same physical/bond device that carries its own IPv4 address, and emit a
`vlan=`/`ip=` pair for each.

- Only the default-route VLAN carries a gateway. Extra VLANs get an empty
  gateway field, because a second default gateway on the kernel cmdline would
  be wrong.
- Each extra VLAN is confirmed interactively (`Add VLAN <id> (<addr>)?`), and
  auto-accepted under `-yes`.
- The serial-console prompt, previously duplicated across the netlink and
  simple paths, is extracted into a shared `consoleArg` helper.

## Testing

- Added `TestCollectKernelArgsNetlink_MultiVLANSameParent`: a public VLAN
  (with gateway) and a private VLAN (no gateway) on the same parent both
  produce `vlan=`/`ip=` lines, and the private VLAN never carries the default
  gateway.
- gofmt / `go vet` / golangci-lint clean; full package tests pass on
  linux/amd64.
- Verified on real hardware (`eno1` with VLAN 321 public + VLAN 403 private).
  Generated args:
  `vlan=eno1.321:eno1 ip=<pub>::<gw>:<mask>:<host>:eno1.321:none vlan=eno1.403:eno1 ip=<priv>:::<mask>:<host>:eno1.403:none`

## Note

Stacked on top of the onboard-interface-name fix branch
(`fix/network-preserve-onboard-interface-name`); rebase onto main once that
merges.
